### PR TITLE
Fix Vite dev server host configuration for external access

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -14,4 +14,8 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    host: '0.0.0.0',
+    allowedHosts: 'all'
+  }
 })


### PR DESCRIPTION
- Add server.host: '0.0.0.0' to bind to all interfaces
- Set allowedHosts: 'all' to allow external domain access
- Enables access from Daytona workspace URLs