### PR TITLE
Add server config to Vite for external host access

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -14,4 +14,8 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    host: '0.0.0.0',
+    allowedHosts: true
+  }
 })


### PR DESCRIPTION
- Configure host: '0.0.0.0' to allow access from any network interface
- Set allowedHosts: true to accept connections from any hostname
- Enables development server access in containerized environments